### PR TITLE
Recover from retryable signing faults

### DIFF
--- a/src/main/kotlin/com/boltfortesla/teslafleetsdk/net/HandshakeRecoveryStrategy.kt
+++ b/src/main/kotlin/com/boltfortesla/teslafleetsdk/net/HandshakeRecoveryStrategy.kt
@@ -1,0 +1,23 @@
+package com.boltfortesla.teslafleetsdk.net
+
+import com.boltfortesla.teslafleetsdk.TeslaFleetApi.SharedSecretFetcher
+import com.boltfortesla.teslafleetsdk.handshake.Handshaker
+import com.boltfortesla.teslafleetsdk.handshake.SessionInfoRepository
+import com.tesla.generated.universalmessage.UniversalMessage.Domain
+
+/** [MessageFaultRecoveryStrategy] that performs a new Handshake */
+internal class HandshakeRecoveryStrategy(
+  private val handshaker: Handshaker,
+  private val sessionInfoRepository: SessionInfoRepository,
+  private val vin: String,
+  private val domain: Domain,
+  private val sharedSecretFetcher: SharedSecretFetcher,
+) : MessageFaultRecoveryStrategy {
+  override suspend fun recover() {
+    sessionInfoRepository.set(
+      vin,
+      domain,
+      handshaker.performHandshake(vin, domain, sharedSecretFetcher)
+    )
+  }
+}

--- a/src/main/kotlin/com/boltfortesla/teslafleetsdk/net/HandshakeRecoveryStrategyFactory.kt
+++ b/src/main/kotlin/com/boltfortesla/teslafleetsdk/net/HandshakeRecoveryStrategyFactory.kt
@@ -1,0 +1,23 @@
+package com.boltfortesla.teslafleetsdk.net
+
+import com.boltfortesla.teslafleetsdk.TeslaFleetApi.SharedSecretFetcher
+import com.boltfortesla.teslafleetsdk.handshake.Handshaker
+import com.boltfortesla.teslafleetsdk.handshake.SessionInfoRepository
+import com.tesla.generated.universalmessage.UniversalMessage
+
+/** Factory for [HandshakeRecoveryStrategy] */
+internal class HandshakeRecoveryStrategyFactory(
+  private val handshaker: Handshaker,
+  private val sessionInfoRepository: SessionInfoRepository
+) {
+  /**
+   * @param vin VIN of the vehicle the command will be sent to
+   * @param domain the [Domain] the handshake should be performed for.
+   * @param sharedSecretFetcher an implementation of [SharedSecretFetcher]
+   */
+  fun create(
+    vin: String,
+    domain: UniversalMessage.Domain,
+    sharedSecretFetcher: SharedSecretFetcher
+  ) = HandshakeRecoveryStrategy(handshaker, sessionInfoRepository, vin, domain, sharedSecretFetcher)
+}

--- a/src/main/kotlin/com/boltfortesla/teslafleetsdk/net/MessageFaultRecoveryStrategy.kt
+++ b/src/main/kotlin/com/boltfortesla/teslafleetsdk/net/MessageFaultRecoveryStrategy.kt
@@ -1,0 +1,14 @@
+package com.boltfortesla.teslafleetsdk.net
+
+import com.boltfortesla.teslafleetsdk.log.Log
+
+/** Interface for a Strategy of how to recover from a retryable Message Fault. */
+internal fun interface MessageFaultRecoveryStrategy {
+  /** Perform an action to recover from the message fault. */
+  suspend fun recover()
+
+  companion object {
+    /** A [MessageFaultRecoveryStrategy] that does nothing. */
+    val NONE = MessageFaultRecoveryStrategy { Log.i("Not recovering from message fault") }
+  }
+}

--- a/src/main/kotlin/com/boltfortesla/teslafleetsdk/net/NetworkExecutor.kt
+++ b/src/main/kotlin/com/boltfortesla/teslafleetsdk/net/NetworkExecutor.kt
@@ -6,8 +6,12 @@ internal interface NetworkExecutor {
    * Executes [action].
    *
    * Returns a [Result] containing the response object, or an exception on failure.
+   *
+   * @param messageFaultRecoveryStrategy a [MessageFaultRecoveryStrategy] to use if [action] fails
+   *   with a retryable signed message fault
    */
   suspend fun <T> execute(
+    messageFaultRecoveryStrategy: MessageFaultRecoveryStrategy = MessageFaultRecoveryStrategy.NONE,
     action: suspend () -> T,
   ): Result<T>
 }

--- a/src/main/kotlin/com/boltfortesla/teslafleetsdk/net/NetworkRetrier.kt
+++ b/src/main/kotlin/com/boltfortesla/teslafleetsdk/net/NetworkRetrier.kt
@@ -2,6 +2,7 @@ package com.boltfortesla.teslafleetsdk.net
 
 import com.boltfortesla.teslafleetsdk.TeslaFleetApi.RetryConfig
 import com.boltfortesla.teslafleetsdk.log.Log
+import com.tesla.generated.universalmessage.UniversalMessage
 import java.time.Duration
 import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.CancellationException
@@ -13,7 +14,8 @@ import retrofit2.HttpException
  * Manages retrying network requests
  *
  * The [RetryConfig] configures how retries are performed. Retries are backed off, using
- * [jitterFactorCalculator] to add jitter to the backoff
+ * [jitterFactorCalculator] to add jitter to the backoff. [messageFaultRecoveryStrategy] is invoked
+ * if there is a retryable signed message failure (see [RETRYABLE_MESSAGE_FAULTS]).
  *
  * Requests are only retried if they come back with a [RATE_LIMITED_CODE], or the caller determines
  * it is retryable (see [doWithRetries] isRetryable parameter).
@@ -23,11 +25,12 @@ import retrofit2.HttpException
  */
 internal class NetworkRetrier(
   private val retryConfig: RetryConfig,
-  private val jitterFactorCalculator: JitterFactorCalculator
+  private val jitterFactorCalculator: JitterFactorCalculator,
+  private val messageFaultRecoveryStrategy: MessageFaultRecoveryStrategy,
 ) {
   suspend fun <T> doWithRetries(
     action: suspend () -> Result<T>,
-    isRetryable: (Result<T>) -> Boolean,
+    isRetryable: Result<T>.() -> Boolean,
   ): Result<T> {
     var retryCount = 0
     var currentDelay = retryConfig.initialBackoffDelayMs
@@ -35,8 +38,9 @@ internal class NetworkRetrier(
     while (coroutineContext.isActive) {
       Log.d("Making request")
       val result = action()
-      Log.d("Request complete. Retrying if necessary")
-      if (isRetryable(result) && retryCount++ < retryConfig.maxRetries) {
+      Log.d("Request complete")
+      val retryable = result.isRetryable() || result.isTemporarySigningError()
+      if (retryable && retryCount++ < retryConfig.maxRetries) {
         val delay =
           (result.calculateDelay(currentDelay) * jitterFactorCalculator.calculate()).toLong()
         Log.d("Retrying in $delay ms. retryCount: $retryCount")
@@ -45,6 +49,12 @@ internal class NetworkRetrier(
           (currentDelay * retryConfig.backoffFactor)
             .toLong()
             .coerceAtMost(retryConfig.maxBackoffDelay)
+        if (result.isTemporarySigningError()) {
+          Log.d(
+            "Temporary signing error (${result.exceptionOrNull()}) detected. Attempting recovery"
+          )
+          messageFaultRecoveryStrategy.recover()
+        }
       } else {
         Log.d("Not retrying")
         return result
@@ -68,8 +78,22 @@ internal class NetworkRetrier(
     return currentDelay
   }
 
+  private fun Result<*>.isTemporarySigningError() =
+    RETRYABLE_MESSAGE_FAULTS.contains((exceptionOrNull() as? SignedMessagesFaultException)?.fault)
+
   companion object {
     private const val RATE_LIMITED_CODE = 429
     private const val RETRY_AFTER_HEADER = "Retry-After"
+    val RETRYABLE_MESSAGE_FAULTS =
+      listOf(
+        UniversalMessage.MessageFault_E.MESSAGEFAULT_ERROR_BUSY,
+        UniversalMessage.MessageFault_E.MESSAGEFAULT_ERROR_TIMEOUT,
+        UniversalMessage.MessageFault_E.MESSAGEFAULT_ERROR_INVALID_SIGNATURE,
+        UniversalMessage.MessageFault_E.MESSAGEFAULT_ERROR_INVALID_TOKEN_OR_COUNTER,
+        UniversalMessage.MessageFault_E.MESSAGEFAULT_ERROR_INTERNAL,
+        UniversalMessage.MessageFault_E.MESSAGEFAULT_ERROR_INCORRECT_EPOCH,
+        UniversalMessage.MessageFault_E.MESSAGEFAULT_ERROR_TIME_EXPIRED,
+        UniversalMessage.MessageFault_E.MESSAGEFAULT_ERROR_TIME_TO_LIVE_TOO_LONG,
+      )
   }
 }

--- a/src/main/kotlin/com/boltfortesla/teslafleetsdk/net/api/vehicle/commands/SignedCommandSender.kt
+++ b/src/main/kotlin/com/boltfortesla/teslafleetsdk/net/api/vehicle/commands/SignedCommandSender.kt
@@ -1,5 +1,6 @@
 package com.boltfortesla.teslafleetsdk.net.api.vehicle.commands
 
+import com.boltfortesla.teslafleetsdk.TeslaFleetApi.SharedSecretFetcher
 import com.boltfortesla.teslafleetsdk.handshake.SessionInfo
 import com.boltfortesla.teslafleetsdk.net.api.vehicle.commands.response.VehicleCommandResponse.CommandProtocolResponse
 import com.google.protobuf.GeneratedMessageV3
@@ -8,12 +9,14 @@ import com.google.protobuf.GeneratedMessageV3
 internal interface SignedCommandSender {
   /**
    * Signs [message] using [sessionInfo] and [clientPublicKey], and sends the request.
+   * [sharedSecretFetcher] is used if there is a signed message fault.
    *
    * Returns a [Result] containing a [CommandProtocolResponse]
    */
   suspend fun signAndSend(
     message: GeneratedMessageV3,
     sessionInfo: SessionInfo,
-    clientPublicKey: ByteArray
+    clientPublicKey: ByteArray,
+    sharedSecretFetcher: SharedSecretFetcher
   ): Result<CommandProtocolResponse>
 }

--- a/src/main/kotlin/com/boltfortesla/teslafleetsdk/net/api/vehicle/commands/SignedCommandSenderImpl.kt
+++ b/src/main/kotlin/com/boltfortesla/teslafleetsdk/net/api/vehicle/commands/SignedCommandSenderImpl.kt
@@ -1,8 +1,10 @@
 package com.boltfortesla.teslafleetsdk.net.api.vehicle.commands
 
+import com.boltfortesla.teslafleetsdk.TeslaFleetApi.SharedSecretFetcher
 import com.boltfortesla.teslafleetsdk.commands.CommandSigner
 import com.boltfortesla.teslafleetsdk.handshake.SessionInfo
 import com.boltfortesla.teslafleetsdk.log.Log
+import com.boltfortesla.teslafleetsdk.net.HandshakeRecoveryStrategyFactory
 import com.boltfortesla.teslafleetsdk.net.NetworkExecutor
 import com.boltfortesla.teslafleetsdk.net.SignedMessagesFaultException
 import com.boltfortesla.teslafleetsdk.net.api.vehicle.commands.response.VehicleCommandResponse.CommandProtocolResponse
@@ -24,12 +26,14 @@ internal class SignedCommandSenderImpl(
   private val commandSigner: CommandSigner,
   private val vehicleEndpoints: VehicleEndpoints,
   private val networkExecutor: NetworkExecutor,
+  private val handshakeRecoveryStrategyFactory: HandshakeRecoveryStrategyFactory,
   private val vin: String,
 ) : SignedCommandSender {
   override suspend fun signAndSend(
     message: GeneratedMessageV3,
     sessionInfo: SessionInfo,
-    clientPublicKey: ByteArray
+    clientPublicKey: ByteArray,
+    sharedSecretFetcher: SharedSecretFetcher,
   ): Result<CommandProtocolResponse> {
     sessionInfo.counter.incrementAndGet()
     val domain =
@@ -43,7 +47,9 @@ internal class SignedCommandSenderImpl(
       }
     val signedMessage = commandSigner.sign(vin, message, sessionInfo, domain, clientPublicKey)
     Log.d("Sending signed command to Fleet API")
-    return networkExecutor.execute {
+    return networkExecutor.execute(
+      handshakeRecoveryStrategyFactory.create(vin, domain, sharedSecretFetcher)
+    ) {
       val rawResponse =
         vehicleEndpoints
           .signedCommand(Base64.getEncoder().encodeToString(signedMessage.toByteArray()))

--- a/src/main/kotlin/com/boltfortesla/teslafleetsdk/net/api/vehicle/commands/VehicleCommandsFactory.kt
+++ b/src/main/kotlin/com/boltfortesla/teslafleetsdk/net/api/vehicle/commands/VehicleCommandsFactory.kt
@@ -9,6 +9,7 @@ import com.boltfortesla.teslafleetsdk.handshake.HandshakerImpl
 import com.boltfortesla.teslafleetsdk.handshake.SessionInfoAuthenticator
 import com.boltfortesla.teslafleetsdk.handshake.SessionInfoRepositoryImpl
 import com.boltfortesla.teslafleetsdk.keys.PublicKeyEncoder
+import com.boltfortesla.teslafleetsdk.net.HandshakeRecoveryStrategyFactory
 import com.boltfortesla.teslafleetsdk.net.JitterFactorCalculator
 import com.boltfortesla.teslafleetsdk.net.NetworkExecutorImpl
 import com.boltfortesla.teslafleetsdk.net.api.vehicle.endpoints.VehicleEndpointsImpl
@@ -69,6 +70,7 @@ internal class VehicleCommandsFactory(
         commandSigner,
         VehicleEndpointsImpl(vin, endpointsApi, networkExecutor),
         networkExecutor,
+        HandshakeRecoveryStrategyFactory(handshaker, sessionInfoRepository),
         vin,
       ),
       sessionInfoRepository

--- a/src/main/kotlin/com/boltfortesla/teslafleetsdk/net/api/vehicle/commands/VehicleCommandsImpl.kt
+++ b/src/main/kotlin/com/boltfortesla/teslafleetsdk/net/api/vehicle/commands/VehicleCommandsImpl.kt
@@ -116,7 +116,6 @@ import com.tesla.generated.vcsec.Vcsec.RKEAction_E.RKE_ACTION_REMOTE_DRIVE
 import com.tesla.generated.vcsec.Vcsec.RKEAction_E.RKE_ACTION_UNLOCK
 import com.tesla.generated.vcsec.closureMoveRequest
 import com.tesla.generated.vcsec.unsignedMessage
-import java.util.concurrent.ConcurrentHashMap
 import kotlin.math.roundToInt
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -140,7 +139,6 @@ internal class VehicleCommandsImpl(
   private val sessionInfoRepository: SessionInfoRepository
 ) : VehicleCommands {
   private val handshakeMutex = Mutex()
-  private val sessionInfoMap = ConcurrentHashMap<Domain, SessionInfo>()
   private var useCommandProtocol = commandProtocolSupported
 
   override suspend fun actuateTrunk(trunk: VehicleCommands.Trunk): Result<VehicleCommandResponse> {
@@ -1137,7 +1135,12 @@ internal class VehicleCommandsImpl(
         val sessionInfo = ensureSessionStarted(domain)
         if (sessionInfo != null && useCommandProtocol) {
           Log.d("Signing command and sending via command protocol")
-          return signedCommandSender.signAndSend(action, sessionInfo, clientPublicKey)
+          return signedCommandSender.signAndSend(
+            action,
+            sessionInfo,
+            clientPublicKey,
+            sharedSecretFetcher
+          )
         }
       } catch (e: Exception) {
         return Result.failure(e)

--- a/src/test/kotlin/com/boltfortesla/teslafleetsdk/fixtures/Responses.kt
+++ b/src/test/kotlin/com/boltfortesla/teslafleetsdk/fixtures/Responses.kt
@@ -81,6 +81,12 @@ object Responses {
     }
   }
 
+  val RETRYABLE_SIGNED_MESSAGE_FAULT_RESPONSE = routableMessage {
+    signedMessageStatus = messageStatus {
+      signedMessageFault = MessageFault_E.MESSAGEFAULT_ERROR_BUSY
+    }
+  }
+
   fun signedCommandJson(routableMessage: RoutableMessage): String {
     return "{\"response\": \"${Base64.getEncoder().encodeToString(routableMessage.toByteArray())}\"}"
   }

--- a/src/test/kotlin/com/boltfortesla/teslafleetsdk/net/HandshakeRecoveryStrategyTest.kt
+++ b/src/test/kotlin/com/boltfortesla/teslafleetsdk/net/HandshakeRecoveryStrategyTest.kt
@@ -1,0 +1,75 @@
+package com.boltfortesla.teslafleetsdk.net
+
+import com.boltfortesla.teslafleetsdk.TeslaFleetApi
+import com.boltfortesla.teslafleetsdk.TestKeys
+import com.boltfortesla.teslafleetsdk.crypto.HmacCalculatorImpl
+import com.boltfortesla.teslafleetsdk.encoding.HexCodec.decodeHex
+import com.boltfortesla.teslafleetsdk.encoding.TlvEncoderImpl
+import com.boltfortesla.teslafleetsdk.fixtures.Constants.EPOCH
+import com.boltfortesla.teslafleetsdk.fixtures.Constants.VIN
+import com.boltfortesla.teslafleetsdk.fixtures.Responses
+import com.boltfortesla.teslafleetsdk.fixtures.Responses.HANDSHAKE_RESPONSE
+import com.boltfortesla.teslafleetsdk.fixtures.fakes.FakeIdentifiers
+import com.boltfortesla.teslafleetsdk.handshake.HandshakerImpl
+import com.boltfortesla.teslafleetsdk.handshake.SessionInfo
+import com.boltfortesla.teslafleetsdk.handshake.SessionInfoAuthenticatorImpl
+import com.boltfortesla.teslafleetsdk.handshake.SessionInfoRepositoryImpl
+import com.boltfortesla.teslafleetsdk.keys.Pem
+import com.boltfortesla.teslafleetsdk.keys.PublicKeyEncoderImpl
+import com.boltfortesla.teslafleetsdk.net.api.vehicle.endpoints.createVehicleEndpointsApi
+import com.google.common.truth.Truth.assertThat
+import com.google.protobuf.ByteString
+import com.tesla.generated.signatures.hMACSignatureData
+import com.tesla.generated.signatures.signatureData
+import com.tesla.generated.universalmessage.UniversalMessage.Domain.DOMAIN_INFOTAINMENT
+import com.tesla.generated.universalmessage.copy
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Test
+
+class HandshakeRecoveryStrategyTest {
+  private val server = MockWebServer()
+  private val vehicleEndpointsApi = createVehicleEndpointsApi(server.url("/").toString())
+  private val keyParser = PublicKeyEncoderImpl()
+  private val fakeIdentifiers = FakeIdentifiers()
+  private val sessionInfoRepository = SessionInfoRepositoryImpl()
+  private val handshaker =
+    HandshakerImpl(
+      Pem(TestKeys.CLIENT_PUBLIC_KEY).byteArray(),
+      keyParser,
+      vehicleEndpointsApi,
+      SessionInfoAuthenticatorImpl(TlvEncoderImpl(), HmacCalculatorImpl()),
+      fakeIdentifiers,
+      NetworkExecutorImpl(TeslaFleetApi.RetryConfig(), JitterFactorCalculatorImpl()),
+    )
+
+  @Test
+  fun recover_updatesSessionInfoRepositoryWithNewSessionInfo() = runTest {
+    val modifiedHandshakeResponse =
+      HANDSHAKE_RESPONSE.copy {
+        requestUuid = ByteString.copyFromUtf8("otherUuid")
+        signatureData = signatureData {
+          sessionInfoTag = hMACSignatureData {
+            tag =
+              ByteString.fromHex("8c1c0cc6526bc9012b4e77c1368bee68d4edd9800eb567eb0bfb6db202adafa6")
+          }
+        }
+      }
+    val sharedSecret = "sharedSecret".toByteArray()
+    server.enqueue(
+      MockResponse()
+        .setBody(Responses.signedCommandJson(modifiedHandshakeResponse))
+        .setResponseCode(200)
+    )
+
+    HandshakeRecoveryStrategy(handshaker, sessionInfoRepository, VIN, DOMAIN_INFOTAINMENT) {
+        sharedSecret
+      }
+      .recover()
+
+    assertThat(sessionInfoRepository.get(VIN, DOMAIN_INFOTAINMENT))
+      .isEqualTo(SessionInfo(EPOCH.decodeHex(), 2650, AtomicInteger(6), sharedSecret))
+  }
+}

--- a/src/test/kotlin/com/boltfortesla/teslafleetsdk/net/NetworkExecutorImplTest.kt
+++ b/src/test/kotlin/com/boltfortesla/teslafleetsdk/net/NetworkExecutorImplTest.kt
@@ -1,11 +1,9 @@
 package com.boltfortesla.teslafleetsdk.net
 
 import com.boltfortesla.teslafleetsdk.TeslaFleetApi.RetryConfig
-import com.boltfortesla.teslafleetsdk.net.NetworkExecutorImpl.Companion.RETRYABLE_MESSAGE_FAULTS
 import com.boltfortesla.teslafleetsdk.net.NetworkExecutorImpl.Companion.RETRYABLE_STATUS_CODES
 import com.boltfortesla.teslafleetsdk.net.api.vehicle.commands.VehicleTemporarilyUnavailableException
 import com.google.common.truth.Truth.assertThat
-import com.tesla.generated.universalmessage.UniversalMessage.MessageFault_E
 import java.io.IOException
 import kotlinx.coroutines.test.runTest
 import okhttp3.ResponseBody.Companion.toResponseBody
@@ -95,25 +93,6 @@ class NetworkExecutorImplTest {
     assertThat(response.isFailure).isTrue()
     val exception = response.exceptionOrNull() as HttpException
     assertThat(exception.code()).isEqualTo(500)
-  }
-
-  @Test
-  fun fails_retryableMessageFault_retries() = runTest {
-    val networkExecutorImpl = NetworkExecutorImpl(RetryConfig(), jitterFactorCalculator)
-    var executionCount = 0
-
-    val response =
-      networkExecutorImpl.execute {
-        val fault =
-          RETRYABLE_MESSAGE_FAULTS.getOrNull(executionCount++)
-            ?: MessageFault_E.MESSAGEFAULT_ERROR_UNKNOWN_KEY_ID
-        throw SignedMessagesFaultException(fault)
-      }
-
-    assertThat(executionCount).isEqualTo(RETRYABLE_MESSAGE_FAULTS.size + 1)
-    assertThat(response.isFailure).isTrue()
-    val exception = response.exceptionOrNull() as SignedMessagesFaultException
-    assertThat(exception.fault).isEqualTo(MessageFault_E.MESSAGEFAULT_ERROR_UNKNOWN_KEY_ID)
   }
 
   @Test

--- a/src/test/kotlin/com/boltfortesla/teslafleetsdk/net/NetworkRetrierTest.kt
+++ b/src/test/kotlin/com/boltfortesla/teslafleetsdk/net/NetworkRetrierTest.kt
@@ -4,13 +4,19 @@ package com.boltfortesla.teslafleetsdk.net
 
 import com.boltfortesla.teslafleetsdk.TeslaFleetApi.RetryConfig
 import com.google.common.truth.Truth.assertThat
+import com.tesla.generated.universalmessage.UniversalMessage.MessageFault_E
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.runTest
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
 
 class NetworkRetrierTest {
 
@@ -22,7 +28,7 @@ class NetworkRetrierTest {
     }
 
   private var actionCount = 0
-  private val expectedResult = Result.success(Unit)
+  private var expectedResult = Result.success(Unit)
   private val fakeAction: () -> Result<Unit> = {
     actionCount++
     expectedResult
@@ -32,7 +38,8 @@ class NetworkRetrierTest {
 
   @Test
   fun doWithRetries_success_callsActionOnce() = runTest {
-    val networkRetrier = NetworkRetrier(RetryConfig(), jitterFactorCalculator)
+    val networkRetrier =
+      NetworkRetrier(RetryConfig(), jitterFactorCalculator, MessageFaultRecoveryStrategy.NONE)
 
     val result = networkRetrier.doWithRetries(fakeAction) { false }
 
@@ -42,7 +49,12 @@ class NetworkRetrierTest {
 
   @Test
   fun doWithRetries_fails_retriesMaxRetries() = runTest {
-    val networkRetrier = NetworkRetrier(RetryConfig(maxRetries = 5), jitterFactorCalculator)
+    val networkRetrier =
+      NetworkRetrier(
+        RetryConfig(maxRetries = 5),
+        jitterFactorCalculator,
+        MessageFaultRecoveryStrategy.NONE
+      )
 
     val result = networkRetrier.doWithRetries(fakeAction) { true }
 
@@ -52,7 +64,12 @@ class NetworkRetrierTest {
 
   @Test
   fun doWithRetries_failsThenSucceeds_retriesUntilSuccess() = runTest {
-    val networkRetrier = NetworkRetrier(RetryConfig(maxRetries = 5), jitterFactorCalculator)
+    val networkRetrier =
+      NetworkRetrier(
+        RetryConfig(maxRetries = 5),
+        jitterFactorCalculator,
+        MessageFaultRecoveryStrategy.NONE
+      )
 
     val result = networkRetrier.doWithRetries(fakeAction) { actionCount <= 3 }
 
@@ -62,9 +79,19 @@ class NetworkRetrierTest {
 
   @Test
   fun doWithRetries_fails_noRetries_callsActionOnce() = runTest {
-    val networkRetrier = NetworkRetrier(RetryConfig(maxRetries = 0), jitterFactorCalculator)
+    val networkRetrier =
+      NetworkRetrier(
+        RetryConfig(maxRetries = 0),
+        jitterFactorCalculator,
+        MessageFaultRecoveryStrategy.NONE
+      )
 
-    val result = networkRetrier.doWithRetries(fakeAction) { true }
+    val result =
+      networkRetrier.doWithRetries(
+        fakeAction,
+      ) {
+        true
+      }
 
     assertThat(actionCount).isEqualTo(1)
     assertThat(result).isEqualTo(expectedResult)
@@ -75,14 +102,73 @@ class NetworkRetrierTest {
     val networkRetrier =
       NetworkRetrier(
         RetryConfig(maxRetries = 5, initialBackoffDelayMs = 100, backoffFactor = 1.5),
-        jitterFactorCalculator
+        jitterFactorCalculator,
+        MessageFaultRecoveryStrategy.NONE
       )
 
-    val result = scope.async { networkRetrier.doWithRetries(fakeAction) { true } }
+    val result =
+      scope.async {
+        networkRetrier.doWithRetries(
+          fakeAction,
+        ) {
+          true
+        }
+      }
     dispatcher.scheduler.runCurrent()
 
     assertThat(actionCount).isEqualTo(1)
     for (delaysAndCounts in listOf(100L to 2, 150L to 3, 225L to 4, 338L to 5, 507L to 6)) {
+      dispatcher.advanceTimeByAndRun(delaysAndCounts.first)
+      assertThat(actionCount).isEqualTo(delaysAndCounts.second)
+    }
+    runTest { assertThat(result.await()).isEqualTo(expectedResult) }
+  }
+
+  @Test
+  fun doWithReties_429_usesRetryAfterHeader() {
+    expectedResult =
+      Result.failure(
+        HttpException(
+          Response.error<Any>(
+            "".toResponseBody(),
+            okhttp3.Response.Builder() //
+              .body("".toResponseBody())
+              .code(429)
+              .message("Response.error()")
+              .protocol(Protocol.HTTP_1_1)
+              .addHeader("Retry-After", "12345")
+              .request(Request.Builder().url("http://localhost/").build())
+              .build()
+          )
+        )
+      )
+    val networkRetrier =
+      NetworkRetrier(
+        RetryConfig(maxRetries = 5),
+        jitterFactorCalculator,
+        MessageFaultRecoveryStrategy.NONE
+      )
+
+    val result =
+      scope.async {
+        networkRetrier.doWithRetries(
+          fakeAction,
+        ) {
+          true
+        }
+      }
+    dispatcher.scheduler.runCurrent()
+
+    assertThat(actionCount).isEqualTo(1)
+    val retryAfterMs = (12345 * 1000).toLong()
+    for (delaysAndCounts in
+      listOf(
+        retryAfterMs to 2,
+        retryAfterMs to 3,
+        retryAfterMs to 4,
+        retryAfterMs to 5,
+        retryAfterMs to 6
+      )) {
       dispatcher.advanceTimeByAndRun(delaysAndCounts.first)
       assertThat(actionCount).isEqualTo(delaysAndCounts.second)
     }
@@ -99,11 +185,18 @@ class NetworkRetrierTest {
           backoffFactor = 1.75,
           maxBackoffDelay = 200
         ),
-        jitterFactorCalculator
+        jitterFactorCalculator,
+        MessageFaultRecoveryStrategy.NONE
       )
 
     val result =
-      CoroutineScope(dispatcher).async { networkRetrier.doWithRetries(fakeAction) { true } }
+      CoroutineScope(dispatcher).async {
+        networkRetrier.doWithRetries(
+          fakeAction,
+        ) {
+          true
+        }
+      }
     dispatcher.scheduler.runCurrent()
 
     assertThat(actionCount).isEqualTo(1)
@@ -128,11 +221,18 @@ class NetworkRetrierTest {
           override fun calculate(): Double {
             return 1.10
           }
-        }
+        },
+        MessageFaultRecoveryStrategy.NONE
       )
 
     val result =
-      CoroutineScope(dispatcher).async { networkRetrier.doWithRetries(fakeAction) { true } }
+      CoroutineScope(dispatcher).async {
+        networkRetrier.doWithRetries(
+          fakeAction,
+        ) {
+          true
+        }
+      }
     dispatcher.scheduler.runCurrent()
 
     assertThat(actionCount).isEqualTo(1)
@@ -143,6 +243,38 @@ class NetworkRetrierTest {
     }
 
     runTest { assertThat(result.await()).isEqualTo(expectedResult) }
+  }
+
+  @Test
+  fun doWithRetries_retryableMessageFault_attemptsRecovery() = runTest {
+    var recoveryAttempts = 0
+    val networkRetrier =
+      NetworkRetrier(RetryConfig(maxRetries = 5), jitterFactorCalculator) { recoveryAttempts++ }
+    expectedResult =
+      Result.failure(
+        SignedMessagesFaultException(MessageFault_E.MESSAGEFAULT_ERROR_INVALID_SIGNATURE)
+      )
+
+    val result = networkRetrier.doWithRetries(fakeAction) { false }
+
+    assertThat(actionCount).isEqualTo(6)
+    assertThat(recoveryAttempts).isEqualTo(5)
+    assertThat(result).isEqualTo(expectedResult)
+  }
+
+  @Test
+  fun doWithRetries_nonRetryableMessageFault_doesNotAttemptRecovery() = runTest {
+    var recoveryAttempts = 0
+    val networkRetrier =
+      NetworkRetrier(RetryConfig(maxRetries = 5), jitterFactorCalculator) { recoveryAttempts++ }
+    expectedResult =
+      Result.failure(SignedMessagesFaultException(MessageFault_E.MESSAGEFAULT_ERROR_UNKNOWN_KEY_ID))
+
+    val result = networkRetrier.doWithRetries(fakeAction) { false }
+
+    assertThat(actionCount).isEqualTo(1)
+    assertThat(recoveryAttempts).isEqualTo(0)
+    assertThat(result).isEqualTo(expectedResult)
   }
 
   private fun TestDispatcher.advanceTimeByAndRun(delayTimeMillis: Long) {

--- a/src/test/kotlin/com/boltfortesla/teslafleetsdk/net/api/vehicle/commands/SignedCommandSenderImplTest.kt
+++ b/src/test/kotlin/com/boltfortesla/teslafleetsdk/net/api/vehicle/commands/SignedCommandSenderImplTest.kt
@@ -1,17 +1,24 @@
 package com.boltfortesla.teslafleetsdk.net.api.vehicle.commands
 
+import com.boltfortesla.teslafleetsdk.TeslaFleetApi
 import com.boltfortesla.teslafleetsdk.TeslaFleetApi.RetryConfig
 import com.boltfortesla.teslafleetsdk.TestKeys
 import com.boltfortesla.teslafleetsdk.commands.CommandSignerImpl
 import com.boltfortesla.teslafleetsdk.commands.HmacCommandAuthenticator
 import com.boltfortesla.teslafleetsdk.crypto.HmacCalculatorImpl
+import com.boltfortesla.teslafleetsdk.encoding.HexCodec.decodeHex
 import com.boltfortesla.teslafleetsdk.encoding.TlvEncoderImpl
 import com.boltfortesla.teslafleetsdk.fixtures.Constants
 import com.boltfortesla.teslafleetsdk.fixtures.Responses
 import com.boltfortesla.teslafleetsdk.fixtures.Responses.signedCommandJson
 import com.boltfortesla.teslafleetsdk.fixtures.fakes.FakeIdentifiers
+import com.boltfortesla.teslafleetsdk.handshake.HandshakerImpl
 import com.boltfortesla.teslafleetsdk.handshake.SessionInfo
+import com.boltfortesla.teslafleetsdk.handshake.SessionInfoAuthenticatorImpl
+import com.boltfortesla.teslafleetsdk.handshake.SessionInfoRepository
+import com.boltfortesla.teslafleetsdk.keys.Pem
 import com.boltfortesla.teslafleetsdk.keys.PublicKeyEncoderImpl
+import com.boltfortesla.teslafleetsdk.net.HandshakeRecoveryStrategyFactory
 import com.boltfortesla.teslafleetsdk.net.JitterFactorCalculatorImpl
 import com.boltfortesla.teslafleetsdk.net.NetworkExecutorImpl
 import com.boltfortesla.teslafleetsdk.net.SignedMessagesFaultException
@@ -52,7 +59,38 @@ class SignedCommandSenderImplTest {
       "epoch".toByteArray(),
       clockTime = 0,
       counter = AtomicInteger(0),
-      "sharedSecret".toByteArray()
+      Constants.HANDSHAKE_KEY.decodeHex()
+    )
+  private val sharedSecretFetcher =
+    TeslaFleetApi.SharedSecretFetcher { Constants.HANDSHAKE_KEY.decodeHex() }
+  private val fakeSessionInfoRepository =
+    object : SessionInfoRepository {
+      var setCount = 0
+
+      override fun get(vin: String, domain: UniversalMessage.Domain): SessionInfo? {
+        return null
+      }
+
+      override fun set(vin: String, domain: UniversalMessage.Domain, sessionInfo: SessionInfo) {
+        setCount++
+      }
+
+      override fun getAll(): Map<SessionInfoRepository.SessionInfoKey, SessionInfo> {
+        return emptyMap()
+      }
+
+      override fun load(sessionInfoMap: Map<SessionInfoRepository.SessionInfoKey, SessionInfo>) {
+        // no-op
+      }
+    }
+  private val handshaker =
+    HandshakerImpl(
+      Pem(TestKeys.CLIENT_PUBLIC_KEY).byteArray(),
+      PublicKeyEncoderImpl(),
+      vehicleEndpointsApi,
+      SessionInfoAuthenticatorImpl(TlvEncoderImpl(), HmacCalculatorImpl()),
+      fakeIdentifiers,
+      NetworkExecutorImpl(RetryConfig(), JitterFactorCalculatorImpl()),
     )
 
   @Test
@@ -64,7 +102,8 @@ class SignedCommandSenderImplTest {
     )
 
     val response =
-      createSignedCommandSender().signAndSend(ACTION, sessionInfo, TestKeys.CLIENT_PUBLIC_KEY_BYTES)
+      createSignedCommandSender()
+        .signAndSend(ACTION, sessionInfo, TestKeys.CLIENT_PUBLIC_KEY_BYTES, sharedSecretFetcher)
 
     assertThat(response)
       .isEqualTo(
@@ -87,7 +126,8 @@ class SignedCommandSenderImplTest {
     )
 
     val response =
-      createSignedCommandSender().signAndSend(ACTION, sessionInfo, TestKeys.CLIENT_PUBLIC_KEY_BYTES)
+      createSignedCommandSender()
+        .signAndSend(ACTION, sessionInfo, TestKeys.CLIENT_PUBLIC_KEY_BYTES, sharedSecretFetcher)
 
     assertThat(response)
       .isEqualTo(
@@ -102,7 +142,7 @@ class SignedCommandSenderImplTest {
   }
 
   @Test
-  fun fails_signedMessageFault_doesNotRetry() = runTest {
+  fun fails_nonRetryableSignedMessageFault_doesNotRetry() = runTest {
     server.enqueue(
       MockResponse()
         .setResponseCode(200)
@@ -110,13 +150,41 @@ class SignedCommandSenderImplTest {
     )
 
     val response =
-      createSignedCommandSender().signAndSend(ACTION, sessionInfo, TestKeys.CLIENT_PUBLIC_KEY_BYTES)
+      createSignedCommandSender()
+        .signAndSend(ACTION, sessionInfo, TestKeys.CLIENT_PUBLIC_KEY_BYTES, sharedSecretFetcher)
 
     assertThat(server.requestCount).isEqualTo(1)
     assertThat(response.isFailure).isTrue()
     val exception = response.exceptionOrNull() as SignedMessagesFaultException
     assertThat(exception.fault)
       .isEqualTo(UniversalMessage.MessageFault_E.MESSAGEFAULT_ERROR_BAD_PARAMETER)
+  }
+
+  @Test
+  fun fails_retryableSignedMessageFault_recoversAndRetries() = runTest {
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .setBody(signedCommandJson(Responses.RETRYABLE_SIGNED_MESSAGE_FAULT_RESPONSE))
+    )
+    server.enqueue(
+      MockResponse().setBody(signedCommandJson(Responses.HANDSHAKE_RESPONSE)).setResponseCode(200)
+    )
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .setBody(signedCommandJson(Responses.RETRYABLE_SIGNED_MESSAGE_FAULT_RESPONSE))
+    )
+
+    val response =
+      createSignedCommandSender(RetryConfig(maxRetries = 1))
+        .signAndSend(ACTION, sessionInfo, TestKeys.CLIENT_PUBLIC_KEY_BYTES, sharedSecretFetcher)
+
+    assertThat(server.requestCount).isEqualTo(3)
+    assertThat(fakeSessionInfoRepository.setCount).isEqualTo(1)
+    assertThat(response.isFailure).isTrue()
+    val exception = response.exceptionOrNull() as SignedMessagesFaultException
+    assertThat(exception.fault).isEqualTo(UniversalMessage.MessageFault_E.MESSAGEFAULT_ERROR_BUSY)
   }
 
   @Test
@@ -131,7 +199,7 @@ class SignedCommandSenderImplTest {
 
     val response =
       createSignedCommandSender(RetryConfig(maxRetries = 1))
-        .signAndSend(ACTION, sessionInfo, TestKeys.CLIENT_PUBLIC_KEY_BYTES)
+        .signAndSend(ACTION, sessionInfo, TestKeys.CLIENT_PUBLIC_KEY_BYTES, sharedSecretFetcher)
 
     assertThat(response)
       .isEqualTo(
@@ -156,7 +224,7 @@ class SignedCommandSenderImplTest {
 
     val response =
       createSignedCommandSender(RetryConfig(maxRetries = 0))
-        .signAndSend(ACTION, sessionInfo, TestKeys.CLIENT_PUBLIC_KEY_BYTES)
+        .signAndSend(ACTION, sessionInfo, TestKeys.CLIENT_PUBLIC_KEY_BYTES, sharedSecretFetcher)
 
     assertThat(response)
       .isEqualTo(
@@ -179,7 +247,8 @@ class SignedCommandSenderImplTest {
       commandSigner,
       VehicleEndpointsImpl(Constants.VIN, vehicleEndpointsApi, networkExecutor),
       networkExecutor,
-      Constants.VIN
+      HandshakeRecoveryStrategyFactory(handshaker, fakeSessionInfoRepository),
+      Constants.VIN,
     )
   }
 


### PR DESCRIPTION
If there is a signing fault when executing a command, attempt a new handshake