### PR TITLE
Immediately fail if a 429 is received when sending a signed command.

### DIFF
--- a/src/main/kotlin/com/boltfortesla/teslafleetsdk/net/NetworkExecutor.kt
+++ b/src/main/kotlin/com/boltfortesla/teslafleetsdk/net/NetworkExecutor.kt
@@ -10,4 +10,8 @@ internal interface NetworkExecutor {
   suspend fun <T> execute(
     action: suspend () -> T,
   ): Result<T>
+
+  companion object {
+    const val HTTP_TOO_MANY_REQUESTS = 429
+  }
 }

--- a/src/main/kotlin/com/boltfortesla/teslafleetsdk/net/NetworkExecutorImpl.kt
+++ b/src/main/kotlin/com/boltfortesla/teslafleetsdk/net/NetworkExecutorImpl.kt
@@ -2,6 +2,8 @@ package com.boltfortesla.teslafleetsdk.net
 
 import com.boltfortesla.teslafleetsdk.TeslaFleetApi.RetryConfig
 import com.boltfortesla.teslafleetsdk.log.Log
+import com.boltfortesla.teslafleetsdk.net.NetworkExecutor.Companion.HTTP_TOO_MANY_REQUESTS
+import com.boltfortesla.teslafleetsdk.net.api.vehicle.commands.UnrecoverableHttpException
 import com.boltfortesla.teslafleetsdk.net.api.vehicle.commands.VehicleTemporarilyUnavailableException
 import com.tesla.generated.universalmessage.UniversalMessage.MessageFault_E
 import java.io.IOException
@@ -40,6 +42,7 @@ internal class NetworkExecutorImpl(
         when (val exception = it.exceptionOrNull()) {
           is IOException,
           is VehicleTemporarilyUnavailableException -> true
+          is UnrecoverableHttpException -> false
           is HttpException -> RETRYABLE_STATUS_CODES.contains(exception.code())
           is SignedMessagesFaultException -> RETRYABLE_MESSAGE_FAULTS.contains(exception.fault)
           else -> false
@@ -53,7 +56,7 @@ internal class NetworkExecutorImpl(
      * A list of HTTP status codes that are considered retryable. Any other status code will not
      * result in a retry.
      */
-    val RETRYABLE_STATUS_CODES = listOf(408, 429, 503, 504)
+    val RETRYABLE_STATUS_CODES = listOf(408, HTTP_TOO_MANY_REQUESTS, 503, 504)
     val RETRYABLE_MESSAGE_FAULTS =
       listOf(
         MessageFault_E.MESSAGEFAULT_ERROR_BUSY,

--- a/src/main/kotlin/com/boltfortesla/teslafleetsdk/net/NetworkRetrier.kt
+++ b/src/main/kotlin/com/boltfortesla/teslafleetsdk/net/NetworkRetrier.kt
@@ -2,6 +2,7 @@ package com.boltfortesla.teslafleetsdk.net
 
 import com.boltfortesla.teslafleetsdk.TeslaFleetApi.RetryConfig
 import com.boltfortesla.teslafleetsdk.log.Log
+import com.boltfortesla.teslafleetsdk.net.NetworkExecutor.Companion.HTTP_TOO_MANY_REQUESTS
 import kotlin.coroutines.coroutineContext
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -16,8 +17,8 @@ import retrofit2.HttpException
  * The [RetryConfig] configures how retries are performed. Retries are backed off, using
  * [jitterFactorCalculator] to add jitter to the backoff
  *
- * Requests are only retried if they come back with a [RATE_LIMITED_CODE], or the caller determines
- * it is retryable (see [doWithRetries] isRetryable parameter).
+ * Requests are only retried if they come back with a [HTTP_TOO_MANY_REQUESTS], or the caller
+ * determines it is retryable (see [doWithRetries] isRetryable parameter).
  *
  * Requests are backed off according to [RetryConfig], however if a request comes back with a 429
  * (rate limited), the "Retry-After" header is used to determine when the request should be retried.
@@ -62,7 +63,7 @@ internal class NetworkRetrier(
     }
 
     val exception = exceptionOrNull() as? HttpException
-    if (exception?.code() != RATE_LIMITED_CODE) {
+    if (exception?.code() != HTTP_TOO_MANY_REQUESTS) {
       return Duration.ZERO
     }
 
@@ -71,7 +72,6 @@ internal class NetworkRetrier(
   }
 
   companion object {
-    private const val RATE_LIMITED_CODE = 429
     private const val RETRY_AFTER_HEADER = "Retry-After"
   }
 }

--- a/src/main/kotlin/com/boltfortesla/teslafleetsdk/net/api/vehicle/commands/UnrecoverableHttpException.kt
+++ b/src/main/kotlin/com/boltfortesla/teslafleetsdk/net/api/vehicle/commands/UnrecoverableHttpException.kt
@@ -1,0 +1,10 @@
+package com.boltfortesla.teslafleetsdk.net.api.vehicle.commands
+
+import retrofit2.HttpException
+import retrofit2.Response
+
+/**
+ * Wrapper for [HttpException] to indicate that the error cannot be recovered from the relevant
+ * request should not be retried.
+ */
+class UnrecoverableHttpException(response: Response<*>) : HttpException(response)


### PR DESCRIPTION
When the signed_command endpoint is rate limited and returns a 429, the response message is invalid. The client should immediately fail in this case, instead of trying to parse the response message.