### PR TITLE
Adds fleet_status check to verify public key presence before executing commands on vehicles

### DIFF
--- a/src/main/kotlin/com/boltfortesla/teslafleetsdk/net/api/vehicle/commands/VehicleCommandsFactory.kt
+++ b/src/main/kotlin/com/boltfortesla/teslafleetsdk/net/api/vehicle/commands/VehicleCommandsFactory.kt
@@ -57,6 +57,7 @@ internal class VehicleCommandsFactory(
         networkExecutor,
       )
 
+    val vehicleEndpoints = VehicleEndpointsImpl(vin, endpointsApi, networkExecutor)
     return VehicleCommandsImpl(
       vin,
       clientPublicKey,
@@ -67,7 +68,7 @@ internal class VehicleCommandsFactory(
       networkExecutor,
       SignedCommandSenderImpl(
         commandSigner,
-        VehicleEndpointsImpl(vin, endpointsApi, networkExecutor),
+        vehicleEndpoints,
         networkExecutor,
         SessionValidatorImpl(sessionInfoAuthenticator),
         sessionInfoRepository,
@@ -75,6 +76,7 @@ internal class VehicleCommandsFactory(
         vin,
       ),
       sessionInfoRepository,
+      vehicleEndpoints,
     )
   }
 }

--- a/src/main/kotlin/com/boltfortesla/teslafleetsdk/net/api/vehicle/endpoints/response/FleetStatusResponse.kt
+++ b/src/main/kotlin/com/boltfortesla/teslafleetsdk/net/api/vehicle/endpoints/response/FleetStatusResponse.kt
@@ -5,4 +5,11 @@ import com.google.gson.annotations.SerializedName
 data class FleetStatusResponse(
   @SerializedName("key_paired_vins") val keyPairedVins: List<String>,
   @SerializedName("unpaired_vins") val unpairedVins: List<String>,
-)
+  @SerializedName("vehicle_info") val vehicleInfo: Map<String, VehicleInfo>,
+) {
+  data class VehicleInfo(
+    @SerializedName("firmware_version") val firmwareVersion: String,
+    @SerializedName("vehicle_command_protocol_required")
+    val vehicleCommandProtocolRequired: Boolean?,
+  )
+}

--- a/src/test/kotlin/com/boltfortesla/teslafleetsdk/fixtures/Responses.kt
+++ b/src/test/kotlin/com/boltfortesla/teslafleetsdk/fixtures/Responses.kt
@@ -146,6 +146,9 @@ object Responses {
   }
   val ELIGIBLE_UPGRADES_RESPONSE by lazy { readResourceFile("eligible_upgrades_response.json") }
   val FLEET_STATUS_RESPONSE by lazy { readResourceFile("fleet_status_response.json") }
+  val FLEET_STATUS_KEY_NOT_PAIRED_RESPONSE by lazy {
+    readResourceFile("fleet_status_key_not_paired_response.json")
+  }
   val FLEET_TELEMETRY_CONFIG_MODIFY_RESPONSE by lazy {
     readResourceFile("fleet_telemetry_config_modify_response.json")
   }

--- a/src/test/kotlin/com/boltfortesla/teslafleetsdk/net/api/FleetApiEndpointsImplTest.kt
+++ b/src/test/kotlin/com/boltfortesla/teslafleetsdk/net/api/FleetApiEndpointsImplTest.kt
@@ -1,6 +1,7 @@
 package com.boltfortesla.teslafleetsdk.net.api
 
 import com.boltfortesla.teslafleetsdk.TeslaFleetApi
+import com.boltfortesla.teslafleetsdk.fixtures.Constants
 import com.boltfortesla.teslafleetsdk.fixtures.Responses.PRODUCTS_RESPONSE
 import com.boltfortesla.teslafleetsdk.net.JitterFactorCalculatorImpl
 import com.boltfortesla.teslafleetsdk.net.NetworkExecutorImpl
@@ -37,7 +38,7 @@ class FleetApiEndpointsImplTest {
           100021,
           429511308124,
           99999,
-          "5YJ3000000NEXUS01",
+          Constants.VIN,
           null,
           "OWNER",
           "Owned",

--- a/src/test/kotlin/com/boltfortesla/teslafleetsdk/net/api/vehicle/endpoints/VehicleEndpointsImplTest.kt
+++ b/src/test/kotlin/com/boltfortesla/teslafleetsdk/net/api/vehicle/endpoints/VehicleEndpointsImplTest.kt
@@ -39,6 +39,7 @@ import com.boltfortesla.teslafleetsdk.net.api.vehicle.endpoints.response.Eligibl
 import com.boltfortesla.teslafleetsdk.net.api.vehicle.endpoints.response.EligibleSubscriptionsResponse.Eligible.BillingOption
 import com.boltfortesla.teslafleetsdk.net.api.vehicle.endpoints.response.EligibleUpgradesResponse
 import com.boltfortesla.teslafleetsdk.net.api.vehicle.endpoints.response.FleetStatusResponse
+import com.boltfortesla.teslafleetsdk.net.api.vehicle.endpoints.response.FleetStatusResponse.VehicleInfo
 import com.boltfortesla.teslafleetsdk.net.api.vehicle.endpoints.response.FleetTelemetryModifyConfigResponse
 import com.boltfortesla.teslafleetsdk.net.api.vehicle.endpoints.response.FleetTelemetryResponse
 import com.boltfortesla.teslafleetsdk.net.api.vehicle.endpoints.response.Invitation
@@ -177,7 +178,15 @@ class VehicleEndpointsImplTest {
     val request = server.takeRequest()
     assertThat(request.path).isEqualTo("/api/1/vehicles/fleet_status")
     assertThat(response.getOrNull())
-      .isEqualTo(FleetApiResponse(FleetStatusResponse(emptyList(), listOf("5YJ3000000NEXUS01"))))
+      .isEqualTo(
+        FleetApiResponse(
+          FleetStatusResponse(
+            listOf(Constants.VIN),
+            emptyList(),
+            mapOf(Constants.VIN to VehicleInfo("123.4", true)),
+          )
+        )
+      )
   }
 
   @Test

--- a/src/test/resources/fleet_status_key_not_paired_response.json
+++ b/src/test/resources/fleet_status_key_not_paired_response.json
@@ -1,9 +1,9 @@
 {
   "response": {
-    "key_paired_vins": [
+    "key_paired_vins": [],
+    "unpaired_vins": [
       "5YJ30123456789ABC"
     ],
-    "unpaired_vins": [],
     "vehicle_info": {
       "5YJ30123456789ABC": {
         "firmware_version": "123.4",

--- a/src/test/resources/products_response.json
+++ b/src/test/resources/products_response.json
@@ -3,7 +3,7 @@
     "id": 100021,
     "user_id": 429511308124,
     "vehicle_id": 99999,
-    "vin": "5YJ3000000NEXUS01",
+    "vin": "5YJ30123456789ABC",
     "color": null,
     "access_type": "OWNER",
     "display_name": "Owned",


### PR DESCRIPTION

* Updates FleetStatusResponse to include "vehicle_info" map which indicates firmware version and whether the command protocol is required
* Updates "supportsCommandSigning" to log the "vehicleCommandProtocolRequired" field from fleet_status. This is not used yet, as verification is pending, but eventually "supportsCommandSigning" may be updated to only consider this field
* If the FleetStatusResponse does not indicate the required key is present on the vehicle, a failure will be returned immediately containing a KeyNotPairedException() and the command will not be executed.